### PR TITLE
Fix movelh-ps and movehl-ps intrinsics

### DIFF
--- a/sse-intrinsics.lisp
+++ b/sse-intrinsics.lisp
@@ -224,8 +224,10 @@
 
 (def-binary-intrinsic move-ss float-sse-pack movss 1 "_mm_move_ss")
 
-(def-binary-intrinsic movehl-ps float-sse-pack movhlps 1 "_mm_movehl_ps")
-(def-binary-intrinsic movelh-ps float-sse-pack movlhps 1 "_mm_movelh_ps")
+(def-binary-intrinsic movehl-ps float-sse-pack movhlps 1 "_mm_movehl_ps"
+                      :mem-alt-insn movlps)
+(def-binary-intrinsic movelh-ps float-sse-pack movlhps 1 "_mm_movelh_ps"
+                      :mem-alt-insn movhps)
 
 (def-unary-intrinsic movemask-ps (unsigned-byte 4) movmskps 1 "_mm_movemask_ps" :arg-type float-sse-pack)
 


### PR DESCRIPTION
- movlhps and movhlps instructions only work with registers. To support operands
  in memory, need to generate movhps and movlps. They have the same opcodes, but
  different assertions in SBCL's assembler.
- Modify def-binary-intrinsic to accept a keyword parameter :mem-alt-insn to
  specify the instruction to use if the src operand is in memory.
